### PR TITLE
make tests work again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "~5.5.5"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.5.0",
+        "orchestra/testbench": "~3.5.3",
         "phpunit/phpunit": "^6.3"
     },
     "autoload": {

--- a/src/DemoModeController.php
+++ b/src/DemoModeController.php
@@ -18,6 +18,10 @@ class DemoModeController extends \Illuminate\Routing\Controller
 
     public function catchFallback(Request $request): RedirectResponse
     {
+        if (!config('demo-mode.enabled')) {
+            abort(404);
+        }
+        
         if (! (new DemoGuard())->hasDemoAccess($request)) {
             return new RedirectResponse(
                 config('demo-mode.redirect_unauthorized_users_to_url')

--- a/tests/DemoModeTest.php
+++ b/tests/DemoModeTest.php
@@ -90,6 +90,16 @@ class DemoModeTest extends TestCase
             ->assertHeader('location', $this->config['redirect_unauthorized_users_to_url']);
     }
 
+    /** @test */
+    public function it_gives_default_404_when_demo_mode_is_disabled()
+    {
+        $this->app['config']->set('demo-mode.enabled', false);
+
+        $this
+            ->get('/qwerty')
+            ->assertStatus(404);
+    }
+
     protected function getWithIp(string $uri, string $ip): TestResponse
     {
         return $this->call('GET', $uri, [], [], [], ['REMOTE_ADDR' => $ip]);

--- a/tests/DemoModeTest.php
+++ b/tests/DemoModeTest.php
@@ -91,12 +91,12 @@ class DemoModeTest extends TestCase
     }
 
     /** @test */
-    public function it_gives_default_404_when_demo_mode_is_disabled()
+    public function it_shows_the_default_404_page_when_demo_mode_is_disabled()
     {
         $this->app['config']->set('demo-mode.enabled', false);
 
         $this
-            ->get('/qwerty')
+            ->get('/non-existing-page')
             ->assertStatus(404);
     }
 

--- a/tests/DemoModeTest.php
+++ b/tests/DemoModeTest.php
@@ -9,7 +9,7 @@ class DemoModeTest extends TestCase
     /** @test */
     public function it_redirects_users_who_have_not_been_granted_access_to_a_work_in_progress_page()
     {
-        $this->disableExceptionHandling();
+        $this->withoutExceptionHandling();
 
         $this->assertCannotVisitSecretPage();
     }


### PR DESCRIPTION
update orchestra version to include latest laravel in test environment and rename function name because of change in a recent laravel version from disableExceptionHandling to withoutExceptionHandling.